### PR TITLE
Add location extras support

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/geolocation/GeolocationModule.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/GeolocationModule.java
@@ -290,11 +290,41 @@ public class GeolocationModule extends ReactContextBaseJavaModule {
     map.putMap("coords", coords);
     map.putDouble("timestamp", location.getTime());
 
+    Bundle bundle = location.getExtras();
+    if (bundle != null) {
+      WritableMap extras = Arguments.createMap();
+      for (String key: bundle.keySet()) {
+        putIntoMap(extras, key, bundle.get(key));
+      }
+
+      map.putMap("extras", extras);
+    }
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
       map.putBoolean("mocked", location.isFromMockProvider());
     }
 
     return map;
+  }
+
+  private static void putIntoMap(WritableMap map, String key, Object value) {
+    if (value instanceof Integer || value instanceof Long) {
+      map.putInt(key, (Integer) value);
+    } else if (value instanceof Float) {
+      map.putDouble(key, (Float) value);
+    } else if (value instanceof Double) {
+      map.putDouble(key, (Double) value);
+    } else if (value instanceof String) {
+      map.putString(key, (String) value);
+    } else if (value instanceof Boolean) {
+      map.putBoolean(key, (Boolean) value);
+    } else if (value instanceof int[]
+            || value instanceof long[]
+            || value instanceof double[]
+            || value instanceof String[]
+            || value instanceof boolean[]) {
+      map.putArray(key,  Arguments.fromArray(value));
+    }
   }
 
   private void emitError(int code, String message) {


### PR DESCRIPTION
# Overview
Android location manager has the ability to accept and forward GPS 'extras' from a mock location. Mock locations are used when an app wants to proxy gps requests to another application.  This is required and very common in the survey industry. A surveyor carries a light weight high end GPS device thats sends data to the manufacturers android app (Trimble mobile manager in this case).  Trimble mobile manager connects via the internet to a GPS correction source. It then applies those corrections to the GPS position and forwards the corrected GPS location to the rest of the applications on the device.  The corrected GPS position is important but equally so are the extras.  The location extra information is make and model of the receiver, the quality of the position, and so forth.  The GPS position is confirmed with the extras when providing a deliverable to the client.

# Test Plan
Tested with trimble mobile manager. 
https://help.trimblegeospatial.com/TMM/Third-party-apps.htm

It forwards location extras. I console logged them for you to see
{
   "gpsTimeStamp":"2021-04-07T12:59:38.0000000",
   "appVersion":"2.7.0.866",
   "diffStatus":null,
   "geoidModel":"EGM96 (Global)",
   "utcTimeStamp":"2021-04-07T12:59:20.0000000",
   "utcTime":null,
   "satellitesSnr":null,
   "vrms":null,
   "satellites":null,
   "satellitesId":null,
   "vdop":null,
   "hrms":null,
   "subscriptionType":null,
   "pdop":null,
   "satellitesView":null,
   "hdop":null,
   "satellitesUse":null,
   "receiverModel":"R10, 555: Trimble",
   "mockProvider":"Trimble Mobile Manager",
   "diffAge":null,
   "satellitesElv":null,
   "satellitesAzm":null,
   "undulation":null,
   "satellitesType":null,
   "totalSatInView":null,
   "diffID":"-1",
   "mslHeight":null
}
