### PR TITLE
Fix android permissions link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Android API >= 18 Positions will also contain a `mocked` boolean to indicate if 
 <p>
   Android API >= 23 Requires an additional step to check for, and request
   the ACCESS_FINE_LOCATION permission using
-  the <a href="https://facebook.github.io/react-native/docs/permissionsandroid.html" target="_blank">PermissionsAndroid API</a>.
+  the <a href="https://facebook.github.io/react-native/docs/permissionsandroid" target="_blank">PermissionsAndroid API</a>.
   Failure to do so may result in a hard crash.
 </p>
 


### PR DESCRIPTION
https://reactnative.dev/docs/permissionsandroid.html gives page not found
https://reactnative.dev/docs/permissionsandroid works
