### PR TITLE
feat(request-auth): add support for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Sets configuration options that will be used in all location requests.
 
 Supported options:
 
-* `skipPermissionRequests` (boolean, iOS-only) - Defaults to `false`. If `true`, you must request permissions before using Geolocation APIs.
+* `skipPermissionRequests` (boolean) - Defaults to `false`. If `true`, you must request permissions before using Geolocation APIs.
 * `authorizationLevel` (string, iOS-only) - Either `"whenInUse"`, `"always"`, or `"auto"`. Changes whether the user will be asked to give "always" or "when in use" location services permission. Any other value or `auto` will use the default behaviour, where the permission level is based on the contents of your `Info.plist`.
 * `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`.  Determines wether to use `Google’s Location Services API` or `Android’s Location API`. The `"auto"` mode defaults to `playServices`, and falls back to Android's Location API if play services aren't available.
 
@@ -196,10 +196,10 @@ Supported options:
 #### `requestAuthorization()`
 
 ```javascript
-Geolocation.requestAuthorization();
+Geolocation.requestAuthorization(success, [error]);
 ```
 
-Request suitable Location permission based on the key configured on pList. If NSLocationAlwaysUsageDescription is set, it will request Always authorization, although if NSLocationWhenInUseUsageDescription is set, it will request InUse authorization.
+Request suitable Location permission. On iOS if NSLocationAlwaysUsageDescription is set, it will request Always authorization, although if NSLocationWhenInUseUsageDescription is set, it will request InUse authorization.
 
 ---
 

--- a/android/src/legacy/RNCGeolocationModule.java
+++ b/android/src/legacy/RNCGeolocationModule.java
@@ -29,7 +29,9 @@ public class RNCGeolocationModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void requestAuthorization() { }
+    public void requestAuthorization(final Callback success, final Callback error) { 
+      mImpl.requestAuthorization(success, error);
+    }
   
     @ReactMethod
     public void getCurrentPosition(

--- a/android/src/main/java/com/reactnativecommunity/geolocation/GeolocationModule.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/GeolocationModule.java
@@ -138,7 +138,9 @@ public class GeolocationModule extends ReactContextBaseJavaModule {
         return;
       }
 
-      requestAuthorization(args -> mLocationManager.startObserving(options), args -> {});
+      requestAuthorization(args -> mLocationManager.startObserving(options), args -> {
+        throw new SecurityException(args.toString());
+      });
     } catch (SecurityException e) {
       throwLocationPermissionMissing(e);
     }

--- a/android/src/main/java/com/reactnativecommunity/geolocation/GeolocationModule.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/GeolocationModule.java
@@ -28,6 +28,7 @@ public class GeolocationModule extends ReactContextBaseJavaModule {
 
   public static final String NAME = "RNCGeolocation";
   private BaseLocationManager mLocationManager;
+  private Configuration mConfiguration;
 
   public GeolocationModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -46,17 +47,57 @@ public class GeolocationModule extends ReactContextBaseJavaModule {
   }
 
   public void setConfiguration(ReadableMap config) {
-    onConfigutationChange(config);
+    mConfiguration = Configuration.fromReactMap(config);
+    onConfigutationChange(mConfiguration);
   }
 
-  private void onConfigutationChange(ReadableMap config) {
-    if (config.hasKey("locationProvider")) {
-      if (config.getString("locationProvider") == "android" && mLocationManager instanceof PlayServicesLocationManager) {
-        mLocationManager = new AndroidLocationManager(mLocationManager.mReactContext);
-      } else if (config.getString("locationProvider") == "playServices" && mLocationManager instanceof AndroidLocationManager) {
-        mLocationManager = new PlayServicesLocationManager(mLocationManager.mReactContext);
-      }
+  private void onConfigutationChange(Configuration config) {
+    if (config.locationProvider == "android" && mLocationManager instanceof PlayServicesLocationManager) {
+      mLocationManager = new AndroidLocationManager(mLocationManager.mReactContext);
+    } else if (config.locationProvider == "playServices" && mLocationManager instanceof AndroidLocationManager) {
+      mLocationManager = new PlayServicesLocationManager(mLocationManager.mReactContext);
     }
+  }
+
+  /**
+   * Requests location permission.
+   */
+  public void requestAuthorization(final Callback success, final Callback error) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      final PermissionsModule perms = getReactApplicationContext().getNativeModule(PermissionsModule.class);
+      ArrayList<String> permissions = new ArrayList<>();
+      permissions.add(Manifest.permission.ACCESS_COARSE_LOCATION);
+      permissions.add( Manifest.permission.ACCESS_FINE_LOCATION);
+      ReadableArray permissionsArray = JavaOnlyArray.from(permissions);
+
+      final Callback onPermissionGranted = args -> {
+        WritableNativeMap result = (WritableNativeMap) args[0];
+        if (result.getString(Manifest.permission.ACCESS_COARSE_LOCATION).equals("granted")) {
+          success.invoke();
+        } else {
+          error.invoke(PositionError.buildError(PositionError.PERMISSION_DENIED, "Location permission was not granted."));
+        }
+      };
+
+      final Callback onPermissionDenied = args -> error.invoke(PositionError.buildError(PositionError.PERMISSION_DENIED, "Failed to request location permission."));
+
+      Callback onPermissionCheckFailed = args -> error.invoke(PositionError.buildError(PositionError.PERMISSION_DENIED, "Failed to check location permission."));
+
+      Callback onPermissionChecked = args -> {
+        boolean hasPermission = (boolean) args[0];
+
+        if (!hasPermission) {
+          perms.requestMultiplePermissions(permissionsArray, new PromiseImpl(onPermissionGranted, onPermissionDenied));
+        } else {
+          success.invoke();
+        }
+      };
+
+      perms.checkPermission(Manifest.permission.ACCESS_FINE_LOCATION, new PromiseImpl(onPermissionChecked, onPermissionCheckFailed));
+      return;
+    }
+
+    success.invoke();
   }
 
   /**
@@ -72,57 +113,12 @@ public class GeolocationModule extends ReactContextBaseJavaModule {
       final Callback success,
       final Callback error) {
     try {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        final PermissionsModule perms = getReactApplicationContext().getNativeModule(PermissionsModule.class);
-        ArrayList<String> permissions = new ArrayList<>();
-        permissions.add(Manifest.permission.ACCESS_COARSE_LOCATION);
-        permissions.add( Manifest.permission.ACCESS_FINE_LOCATION);
-        ReadableArray permissionsArray = JavaOnlyArray.from(permissions);
-
-        final Callback onPermissionGranted = new Callback() {
-          @Override
-          public void invoke(Object... args) {
-            WritableNativeMap result = (WritableNativeMap) args[0];
-            if (result.getString(Manifest.permission.ACCESS_COARSE_LOCATION) == "granted") {
-              mLocationManager.getCurrentLocationData(options, success, error);
-            } else {
-              error.invoke(PositionError.buildError(PositionError.PERMISSION_DENIED, "Location permission was not granted."));
-            }
-          }
-        };
-
-        final Callback onPermissionDenied = new Callback() {
-          @Override
-          public void invoke(Object... args) {
-            error.invoke(PositionError.buildError(PositionError.PERMISSION_DENIED, "Failed to request location permission."));
-          }
-        };
-
-        Callback onPermissionCheckFailed = new Callback() {
-          @Override
-          public void invoke(Object... args) {
-            error.invoke(PositionError.buildError(PositionError.PERMISSION_DENIED, "Failed to check location permission."));
-          }
-        };
-
-        Callback onPermissionChecked = new Callback() {
-          @Override
-          public void invoke(Object... args) {
-            boolean hasPermission = (boolean) args[0];
-
-            if (!hasPermission) {
-              perms.requestMultiplePermissions(permissionsArray, new PromiseImpl(onPermissionGranted, onPermissionDenied));
-            } else {
-              mLocationManager.getCurrentLocationData(options, success, error);
-            }
-          }
-        };
-
-        perms.checkPermission(Manifest.permission.ACCESS_FINE_LOCATION, new PromiseImpl(onPermissionChecked, onPermissionCheckFailed));
+      if (mConfiguration.skipPermissionRequests) {
+        mLocationManager.getCurrentLocationData(options, success, error);
         return;
       }
 
-      mLocationManager.getCurrentLocationData(options, success, error);
+      requestAuthorization(args -> mLocationManager.getCurrentLocationData(options, success, error), error);
     } catch (SecurityException e) {
       throwLocationPermissionMissing(e);
     }
@@ -137,7 +133,12 @@ public class GeolocationModule extends ReactContextBaseJavaModule {
    */
   public void startObserving(ReadableMap options) {
     try {
-      mLocationManager.startObserving(options);
+      if (mConfiguration.skipPermissionRequests) {
+        mLocationManager.startObserving(options);
+        return;
+      }
+
+      requestAuthorization(args -> mLocationManager.startObserving(options), args -> {});
     } catch (SecurityException e) {
       throwLocationPermissionMissing(e);
     }
@@ -161,5 +162,23 @@ public class GeolocationModule extends ReactContextBaseJavaModule {
       "Looks like the app doesn't have the permission to access location.\n" +
       "Add the following line to your app's AndroidManifest.xml:\n" +
       "<uses-permission android:name=\"android.permission.ACCESS_FINE_LOCATION\" />", e);
+  }
+
+  private static class Configuration {
+    String locationProvider;
+    Boolean skipPermissionRequests;
+
+    private Configuration(String locationProvider, boolean skipPermissionRequests) {
+      this.locationProvider = locationProvider;
+      this.skipPermissionRequests = skipPermissionRequests;
+    }
+
+    protected static Configuration fromReactMap(ReadableMap map) {
+      String locationProvider =
+              map.hasKey("locationProvider") ? map.getString("locationProvider") : "auto";
+      boolean skipPermissionRequests =
+              map.hasKey("skipPermissionRequests") ? map.getBoolean("skipPermissionRequests") : false;
+      return new Configuration(locationProvider, skipPermissionRequests);
+    }
   }
 }

--- a/android/src/main/java/com/reactnativecommunity/geolocation/PlayServicesLocationManager.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/PlayServicesLocationManager.java
@@ -24,19 +24,6 @@ public class PlayServicesLocationManager extends BaseLocationManager {
     protected PlayServicesLocationManager(ReactApplicationContext reactContext) {
         super(reactContext);
         mFusedLocationClient = LocationServices.getFusedLocationProviderClient(reactContext.getCurrentActivity());
-        mLocationCallback = new LocationCallback() {
-            @Override
-            public void onLocationResult(LocationResult locationResult) {
-                if (locationResult == null) {
-                    emitError(PositionError.POSITION_UNAVAILABLE, "No location provided by FusedLocationProviderClient.");
-                    return;
-                }
-                for (Location location : locationResult.getLocations()) {
-                    mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                            .emit("geolocationDidChange", locationToMap(location));
-                }
-            }
-        };
     }
 
     @Override
@@ -63,6 +50,21 @@ public class PlayServicesLocationManager extends BaseLocationManager {
 
     @Override
     public void startObserving(ReadableMap options) {
+        if (mLocationCallback == null) {
+            mLocationCallback = new LocationCallback() {
+                @Override
+                public void onLocationResult(LocationResult locationResult) {
+                    if (locationResult == null) {
+                        emitError(PositionError.POSITION_UNAVAILABLE, "No location provided by FusedLocationProviderClient.");
+                        return;
+                    }
+                    for (Location location : locationResult.getLocations()) {
+                        mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                                .emit("geolocationDidChange", locationToMap(location));
+                    }
+                }
+            };
+        };
         LocationOptions locationOptions = LocationOptions.fromReactMap(options);
         LocationRequest locationRequest = LocationRequest.create();
         locationRequest.setInterval(locationOptions.interval);

--- a/android/src/main/java/com/reactnativecommunity/geolocation/PlayServicesLocationManager.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/PlayServicesLocationManager.java
@@ -24,6 +24,19 @@ public class PlayServicesLocationManager extends BaseLocationManager {
     protected PlayServicesLocationManager(ReactApplicationContext reactContext) {
         super(reactContext);
         mFusedLocationClient = LocationServices.getFusedLocationProviderClient(reactContext.getCurrentActivity());
+        mLocationCallback = new LocationCallback() {
+            @Override
+            public void onLocationResult(LocationResult locationResult) {
+                if (locationResult == null) {
+                    emitError(PositionError.POSITION_UNAVAILABLE, "No location provided by FusedLocationProviderClient.");
+                    return;
+                }
+                for (Location location : locationResult.getLocations()) {
+                    mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                            .emit("geolocationDidChange", locationToMap(location));
+                }
+            }
+        };
     }
 
     @Override
@@ -50,21 +63,6 @@ public class PlayServicesLocationManager extends BaseLocationManager {
 
     @Override
     public void startObserving(ReadableMap options) {
-        if (mLocationCallback == null) {
-            mLocationCallback = new LocationCallback() {
-                @Override
-                public void onLocationResult(LocationResult locationResult) {
-                    if (locationResult == null) {
-                        emitError(PositionError.POSITION_UNAVAILABLE, "No location provided by FusedLocationProviderClient.");
-                        return;
-                    }
-                    for (Location location : locationResult.getLocations()) {
-                        mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                                .emit("geolocationDidChange", locationToMap(location));
-                    }
-                }
-            };
-        };
         LocationOptions locationOptions = LocationOptions.fromReactMap(options);
         LocationRequest locationRequest = LocationRequest.create();
         locationRequest.setInterval(locationOptions.interval);

--- a/android/src/turbo/RNCGeolocationModule.java
+++ b/android/src/turbo/RNCGeolocationModule.java
@@ -30,7 +30,9 @@ public class RNCGeolocationModule extends NativeRNCGeolocationSpec {
 
     @Override
     @ReactMethod
-    public void requestAuthorization() { }
+    public void requestAuthorization(Callback success, Callback error) {
+        mImpl.requestAuthorization(success, error);
+    }
 
     @Override
     @ReactMethod

--- a/example/src/configs/SetConfiguration.tsx
+++ b/example/src/configs/SetConfiguration.tsx
@@ -49,46 +49,44 @@ export default function SetConfigurationExample() {
 
   return (
     <View>
+      <View style={styles.row}>
+        <Text>skipPermissionRequests</Text>
+        <Switch
+          onValueChange={() =>
+            setSkipPermissionRequests(!skipPermissionRequests)
+          }
+          value={skipPermissionRequests}
+        />
+      </View>
       {Platform.OS === 'ios' && (
-        <>
-          <View style={styles.row}>
-            <Text>skipPermissionRequests</Text>
-            <Switch
-              onValueChange={() =>
-                setSkipPermissionRequests(!skipPermissionRequests)
-              }
-              value={skipPermissionRequests}
-            />
-          </View>
-          <View style={styles.row}>
-            <Text>authorizationLevel</Text>
-            <View style={styles.segmentControlContainer}>
-              {authorizationLevelOptions.map((item, index) => (
-                <TouchableOpacity
-                  key={`segmented-control-${index}`}
-                  onPress={() =>
-                    setAuthorizationLevel(authorizationLevelOptions[index])
-                  }
+        <View style={styles.row}>
+          <Text>authorizationLevel</Text>
+          <View style={styles.segmentControlContainer}>
+            {authorizationLevelOptions.map((item, index) => (
+              <TouchableOpacity
+                key={`segmented-control-${index}`}
+                onPress={() =>
+                  setAuthorizationLevel(authorizationLevelOptions[index])
+                }
+                style={[
+                  styles.segmentedControlButton,
+                  authorizationLevelOptions.indexOf(authorizationLevel) ===
+                    index && styles.segmentedControlButtonActive,
+                ]}
+              >
+                <Text
                   style={[
-                    styles.segmentedControlButton,
+                    styles.segmentControlText,
                     authorizationLevelOptions.indexOf(authorizationLevel) ===
-                      index && styles.segmentedControlButtonActive,
+                      index && styles.segmentControlTextActive,
                   ]}
                 >
-                  <Text
-                    style={[
-                      styles.segmentControlText,
-                      authorizationLevelOptions.indexOf(authorizationLevel) ===
-                        index && styles.segmentControlTextActive,
-                    ]}
-                  >
-                    {item}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </View>
+                  {item}
+                </Text>
+              </TouchableOpacity>
+            ))}
           </View>
-        </>
+        </View>
       )}
       {Platform.OS === 'android' && (
         <View style={styles.row}>

--- a/example/src/configs/index.tsx
+++ b/example/src/configs/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Platform } from 'react-native';
 import RequestAuthorization from './RequestAuthorization';
 import SetConfiguration from './SetConfiguration';
 
@@ -13,17 +12,14 @@ const configs = [
       return <SetConfiguration />;
     },
   },
-];
-
-if (Platform.OS === 'ios') {
-  configs.push({
+  {
     id: 'requestAuthorization',
     title: 'requestAuthorization()',
     description: 'Request authorization for location services',
     render() {
       return <RequestAuthorization />;
     },
-  });
-}
+  },
+];
 
 export default configs;

--- a/ios/RNCGeolocation.mm
+++ b/ios/RNCGeolocation.mm
@@ -144,6 +144,7 @@ static NSDictionary<NSString *, id> *RNCPositionError(RNCPositionErrorCode code,
   RNCGeolocationConfiguration _locationConfiguration;
   RNCGeolocationOptions _observerOptions;
   CLAuthorizationStatus _lastUpdatedAuthorizationStatus; // used since iOS 14.0+
+  NSMutableArray<RCTResponseSenderBlock> *_queuedAuthorizationCallbacks;
 }
 
 RCT_EXPORT_MODULE()
@@ -172,7 +173,7 @@ RCT_EXPORT_MODULE()
 - (void)beginLocationUpdatesWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy distanceFilter:(CLLocationDistance)distanceFilter useSignificantChanges:(BOOL)useSignificantChanges
 {
   if (!_locationConfiguration.skipPermissionRequests) {
-    [self requestAuthorization];
+    [self requestAuthorization:nil error:nil];
   }
 
   if (!_locationManager) {
@@ -232,12 +233,20 @@ RCT_REMAP_METHOD(setConfiguration, setConfiguration:(RNCGeolocationConfiguration
   _locationConfiguration = config;
 }
 
-RCT_REMAP_METHOD(requestAuthorization, requestAuthorization)
+RCT_REMAP_METHOD(requestAuthorization, requestAuthorization:(RCTResponseSenderBlock)successBlock
+                 error:(RCTResponseSenderBlock)errorBlock)
 {
   if (!_locationManager) {
     _locationManager = [CLLocationManager new];
     _locationManager.delegate = self;
   }
+
+  if (successBlock != nil || errorBlock != nil) {
+    _queuedAuthorizationCallbacks = [NSMutableArray new];
+    [_queuedAuthorizationCallbacks addObject:successBlock];
+    [_queuedAuthorizationCallbacks addObject:errorBlock];
+  }
+    
   BOOL wantsAlways = NO;
   BOOL wantsWhenInUse = NO;
   if (_locationConfiguration.authorizationLevel == RNCGeolocationAuthorizationLevelDefault) {
@@ -407,39 +416,55 @@ RCT_REMAP_METHOD(getCurrentPosition, getCurrentPosition:(RNCGeolocationOptions)o
 
 - (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager
 {
+  CLAuthorizationStatus currentStatus;
+    
   if (@available(iOS 14.0, *)) {
-    if (
-      manager.authorizationStatus == kCLAuthorizationStatusAuthorizedAlways ||
-      manager.authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse
-    ) {
-      [self startMonitoring];
-    } else {
-      NSDictionary<NSString *, id> *jsError = manager.authorizationStatus == kCLAuthorizationStatusRestricted
-        ? RNCPositionError(RNCPositionErrorUnavailable, @"This application is not authorized to use location services")
-        : manager.authorizationStatus == kCLAuthorizationStatusDenied
-          ? RNCPositionError(RNCPositionErrorDenied, nil)
-          : nil;
+    currentStatus = manager.authorizationStatus;
+  } else {
+    currentStatus = [CLLocationManager authorizationStatus];
+  }
+    
+  if (
+    currentStatus == kCLAuthorizationStatusAuthorizedAlways ||
+    currentStatus == kCLAuthorizationStatusAuthorizedWhenInUse
+  ) {
+    if (_queuedAuthorizationCallbacks != nil && _queuedAuthorizationCallbacks.count > 0){
+      _queuedAuthorizationCallbacks.firstObject(@[]);
+    }
+    [self startMonitoring];
+  } else {
+    NSDictionary<NSString *, id> *jsError = currentStatus == kCLAuthorizationStatusRestricted
+      ? RNCPositionError(RNCPositionErrorUnavailable, @"This application is not authorized to use location services")
+      : currentStatus == kCLAuthorizationStatusDenied
+        ? RNCPositionError(RNCPositionErrorDenied, nil)
+        : nil;
 
-      if (jsError != nil) {
-        if (_observingLocation) {
-          [self sendEventWithName:@"geolocationError" body:jsError];
-        }
-
-        // Fire all queued error callbacks
-        for (RNCGeolocationRequest *request in _pendingRequests) {
-          request.errorBlock(@[jsError]);
-          [request.timeoutTimer invalidate];
-        }
-        [_pendingRequests removeAllObjects];
+    if (jsError != nil) {
+      if (_observingLocation) {
+        [self sendEventWithName:@"geolocationError" body:jsError];
+      }
+        
+      if (_queuedAuthorizationCallbacks != nil && _queuedAuthorizationCallbacks.count > 0){
+          _queuedAuthorizationCallbacks.lastObject(@[jsError]);
       }
 
-      // Stop updating if user has explicitly denied authorization for this application, or
-      // location services are disabled in Settings, or any other reason.
-      [self stopMonitoring];
+      // Fire all queued error callbacks
+      for (RNCGeolocationRequest *request in _pendingRequests) {
+        request.errorBlock(@[jsError]);
+        [request.timeoutTimer invalidate];
+      }
+      [_pendingRequests removeAllObjects];
     }
+      
+    _queuedAuthorizationCallbacks = nil;
 
-    _lastUpdatedAuthorizationStatus = manager.authorizationStatus;
+    // Stop updating if user has explicitly denied authorization for this application, or
+    // location services are disabled in Settings, or any other reason.
+    [self stopMonitoring];
   }
+
+  _lastUpdatedAuthorizationStatus = currentStatus;
+
 }
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error

--- a/js/NativeRNCGeolocation.ts
+++ b/js/NativeRNCGeolocation.ts
@@ -43,7 +43,10 @@ export interface Spec extends TurboModule {
     skipPermissionRequests: boolean;
     authorizationLevel?: string;
   }): void;
-  requestAuthorization(): void;
+  requestAuthorization(
+    success: () => void,
+    error: (error: GeolocationError) => void
+  ): void;
   getCurrentPosition(
     options: GeolocationOptions,
     position: (position: GeolocationResponse) => void,

--- a/js/implementation.native.ts
+++ b/js/implementation.native.ts
@@ -59,8 +59,11 @@ export function setRNConfiguration(config: GeolocationConfiguration) {
  *
  * See https://facebook.github.io/react-native/docs/geolocation.html#requestauthorization
  */
-export function requestAuthorization() {
-  RNCGeolocation.requestAuthorization();
+export function requestAuthorization(
+  success: () => void = () => {},
+  error: (error: GeolocationError) => void = logError
+) {
+  RNCGeolocation.requestAuthorization(success, error);
 }
 
 /*

--- a/js/implementation.ts
+++ b/js/implementation.ts
@@ -18,7 +18,10 @@ export function setRNConfiguration(_config: GeolocationConfiguration) {
   throw new Error('setRNConfiguration is not supported by the browser');
 }
 
-export function requestAuthorization() {
+export function requestAuthorization(
+  _success?: () => void,
+  _error?: (error: GeolocationError) => void
+) {
   throw new Error('requestAuthorization is not supported by the browser');
 }
 

--- a/js/index.ts
+++ b/js/index.ts
@@ -60,8 +60,11 @@ const Geolocation = {
     GeolocationModule.stopObserving();
   },
 
-  requestAuthorization: function () {
-    GeolocationModule.requestAuthorization();
+  requestAuthorization: function (
+    success?: () => void,
+    error?: (error: GeolocationError) => void
+  ) {
+    GeolocationModule.requestAuthorization(success, error);
   },
 
   setRNConfiguration: function (config: GeolocationConfiguration) {


### PR DESCRIPTION
# Overview
Added support for `requestAuthorization` method on Android.

# Test Plan
- Confirm if authorization can be requested using just `requestAuthorization`.
- Confirm if invoking `getCurrentPosition` requests authorization if `requestAuthorization` wasn't called.
- Confirm if invoking `getCurrentPosition` with flag `skipPermissionRequest` doesn't requests authorization 
