### PR TITLE
Fix build issues while using `use_frameworks!`

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -17,6 +17,7 @@ target 'GeolocationExample' do
     # to enable hermes on iOS, change `false` to `true` and then install pods
     :hermes_enabled => flags[:hermes_enabled],
     :fabric_enabled => flags[:fabric_enabled],
+    :flipper_configuration => FlipperConfiguration.disabled,
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )

--- a/react-native-geolocation.podspec
+++ b/react-native-geolocation.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m,mm}"
 
   s.dependency 'React-Core'
+  s.frameworks = 'CoreLocation'
 
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
     s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"


### PR DESCRIPTION
# Overview
Fixes https://github.com/michalchudziak/react-native-geolocation/issues/193

Added support for `use_frameworks!` 


# Test Plan
- iOS build with `use_frameworks!` works (flipper, hermes, new arch disabled)
- iOS build w/o `use_frameworks!` works (old arch)
- iOS build w/o `use_frameworks!` works (new arch)
