### PR TITLE
Added a more thorough Usage example, and make skipPermissionRequests optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,23 @@ navigator.geolocation = require('@react-native-community/geolocation');
 ```javascript
 import Geolocation from '@react-native-community/geolocation';
 
-Geolocation.getCurrentPosition(info => console.log(info));
+function() Example() {
+  useEffect(() => {
+    Geolocation.setRNConfiguration({
+      skipPermissionRequests: false,
+      authorizationLevel: 'whenInUse',
+      locationProvider: 'auto',
+    });
+
+    Geolocation.getCurrentPosition(
+      pos => console.debug('Geolocation.getCurrentPosition Result', JSON.stringify(pos)),
+      error => console.error('Geolocation.getCurrentPosition Error', JSON.stringify(error)),
+      {enableHighAccuracy: true},
+    );
+  };
+
+  // ...
+}
 ```
 
 Check out the [example project](example) for more examples.
@@ -128,7 +144,7 @@ Sets configuration options that will be used in all location requests.
 ```ts
 Geolocation.setRNConfiguration(
   config: {
-    skipPermissionRequests: boolean;
+    skipPermissionRequests?: boolean;
     authorizationLevel?: 'always' | 'whenInUse' | 'auto';
     locationProvider?: 'playServices' | 'android' | 'auto';
   }

--- a/js/NativeRNCGeolocation.ts
+++ b/js/NativeRNCGeolocation.ts
@@ -2,7 +2,7 @@ import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
 export type GeolocationConfiguration = {
-  skipPermissionRequests: boolean;
+  skipPermissionRequests?: boolean;
   authorizationLevel?: 'always' | 'whenInUse' | 'auto';
   locationProvider?: 'playServices' | 'android' | 'auto';
 };
@@ -40,8 +40,9 @@ export type GeolocationError = {
 
 export interface Spec extends TurboModule {
   setConfiguration(config: {
-    skipPermissionRequests: boolean;
+    skipPermissionRequests?: boolean;
     authorizationLevel?: string;
+    locationProvider?: string;
   }): void;
   requestAuthorization(
     success: () => void,

--- a/js/implementation.native.ts
+++ b/js/implementation.native.ts
@@ -44,13 +44,13 @@ let updatesEnabled = false;
  */
 export function setRNConfiguration(config: GeolocationConfiguration) {
   RNCGeolocation.setConfiguration({
-    ...config,
+    skipPermissionRequests: config.skipPermissionRequests,
     authorizationLevel:
-      config?.authorizationLevel === 'auto'
+      config.authorizationLevel === 'auto'
         ? undefined
         : config.authorizationLevel,
     locationProvider:
-      config?.locationProvider === 'auto' ? undefined : config.locationProvider,
+      config.locationProvider === 'auto' ? undefined : config.locationProvider,
   });
 }
 


### PR DESCRIPTION
# Overview

When I first looked at the repo, it wasn't clear that the permissions would be handled so easily. The example app has *too many* features, and so gives the impression that all that work is required to get it to work. The API is great, show it off!

I also changed some types for the configuration. The docs say that `skipPermissionRequests` defaults to `false`, but actually it's a required option according to the typescript definition.

# Test Plan

I'm using this fork/branch in my own project - I tested the changes to `setRNConfiguration` and types on ios and android.

On Android, I tested the changes by logging the value here:
```java
    protected static Configuration fromReactMap(ReadableMap map) {
      String locationProvider =
              map.hasKey("locationProvider") ? map.getString("locationProvider") : "auto";
      boolean skipPermissionRequests =
              map.hasKey("skipPermissionRequests") ? map.getBoolean("skipPermissionRequests") : false;
      System.out.println("=============== GeolocationModule.java at line 188 ===============");
      System.out.println("locationProvider:" + locationProvider);
      System.out.println("skipPermissionRequests:" + skipPermissionRequests);
      return new Configuration(locationProvider, skipPermissionRequests);
    }
```

And similarly on iOS
```objc
  NSDictionary<NSString *, id> *options = [RCTConvert NSDictionary:json];
  NSLog(@"options: %@", options);
```