### PR TITLE
Set location API as a default provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Supports TurboModules ⚡️ and legacy React Native architecture.
 
 Fully compatible with TypeScript.
 
-Uses modern [Play Services Location API](https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderClient.html) and falls back to legacy [Android Location API](https://developer.android.com/reference/android/location/Location) if PlayServices aren't available.
+Supports modern [Play Services Location API](https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderClient.html).
 
 
 ## Supported platforms
@@ -139,7 +139,7 @@ Supported options:
 
 * `skipPermissionRequests` (boolean) - Defaults to `false`. If `true`, you must request permissions before using Geolocation APIs.
 * `authorizationLevel` (string, iOS-only) - Either `"whenInUse"`, `"always"`, or `"auto"`. Changes whether the user will be asked to give "always" or "when in use" location services permission. Any other value or `auto` will use the default behaviour, where the permission level is based on the contents of your `Info.plist`.
-* `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`.  Determines wether to use `Google’s Location Services API` or `Android’s Location API`. The `"auto"` mode defaults to `playServices`, and falls back to Android's Location API if play services aren't available.
+* `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`.  Determines wether to use `Google’s Location Services API` or `Android’s Location API`. The `"auto"` mode defaults to `android`, and falls back to Android's Location API if play services aren't available.
 
 ---
 

--- a/android/src/main/java/com/reactnativecommunity/geolocation/GeolocationModule.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/GeolocationModule.java
@@ -34,13 +34,7 @@ public class GeolocationModule extends ReactContextBaseJavaModule {
   public GeolocationModule(ReactApplicationContext reactContext) {
     super(reactContext);
     mConfiguration = Configuration.getDefault();
-    GoogleApiAvailability availability = new GoogleApiAvailability();
-    if (availability.isGooglePlayServicesAvailable(reactContext.getApplicationContext()) == ConnectionResult.SUCCESS) {
-      mLocationManager = new PlayServicesLocationManager(reactContext);
-    } else {
-      mLocationManager = new AndroidLocationManager(reactContext);
-    }
-
+    mLocationManager = new AndroidLocationManager(reactContext);
   }
 
   @Override
@@ -54,10 +48,14 @@ public class GeolocationModule extends ReactContextBaseJavaModule {
   }
 
   private void onConfigurationChange(Configuration config) {
+    ReactApplicationContext reactContext = mLocationManager.mReactContext;
     if (Objects.equals(config.locationProvider, "android") && mLocationManager instanceof PlayServicesLocationManager) {
-      mLocationManager = new AndroidLocationManager(mLocationManager.mReactContext);
+      mLocationManager = new AndroidLocationManager(reactContext);
     } else if (Objects.equals(config.locationProvider, "playServices") && mLocationManager instanceof AndroidLocationManager) {
-      mLocationManager = new PlayServicesLocationManager(mLocationManager.mReactContext);
+      GoogleApiAvailability availability = new GoogleApiAvailability();
+      if (availability.isGooglePlayServicesAvailable(reactContext.getApplicationContext()) == ConnectionResult.SUCCESS) {
+        mLocationManager = new PlayServicesLocationManager(reactContext);
+      }
     }
   }
 


### PR DESCRIPTION
# Overview
Due to the fact that `FusedLocationProvider` implementation is relatively new and doesn't cover some edge cases, I'd like to keep `AndroidLocationProvider` as default until it's better tested and the issues are resolved. 


# Test Plan
- Android is used as a default location provider
