### PR TITLE
Add null Activity check in PlayServicesLocationManager.getCurrentLocationData

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/geolocation/PlayServicesLocationManager.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/PlayServicesLocationManager.java
@@ -1,6 +1,7 @@
 package com.reactnativecommunity.geolocation;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.location.Location;
 import android.os.Build;
 import android.os.Looper;
@@ -45,9 +46,16 @@ public class PlayServicesLocationManager extends BaseLocationManager {
     public void getCurrentLocationData(ReadableMap options, Callback success, Callback error) {
         AndroidLocationManager.LocationOptions locationOptions = AndroidLocationManager.LocationOptions.fromReactMap(options);
 
+        Activity currentActivity = mReactContext.getCurrentActivity();
+
+        if (currentActivity == null) {
+            error.invoke(PositionError.buildError(PositionError.ACTIVITY_NULL, "mReactContext.getCurrentActivity() returned null but should be non-null in getCurrentLocationData"));
+            return;
+        }
+
         try {
             mFusedLocationClient.getLastLocation()
-                    .addOnSuccessListener(mReactContext.getCurrentActivity(), location -> {
+                    .addOnSuccessListener(currentActivity, location -> {
                         if (location != null && (SystemClock.currentTimeMillis() - location.getTime()) < locationOptions.maximumAge) {
                             success.invoke(locationToMap(location));
                         } else {

--- a/android/src/main/java/com/reactnativecommunity/geolocation/PositionError.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/PositionError.java
@@ -32,6 +32,12 @@ public class PositionError {
    */
   public static int TIMEOUT = 3;
 
+  /**
+   * Getting the current Activity returned null, but the logic requires a non-null Activity.
+   * This error can then be returned to inform the user of some underlying Android error.
+   */
+  public static int ACTIVITY_NULL = 4;
+
   public static WritableMap buildError(int code, String message) {
     WritableMap error = Arguments.createMap();
     error.putInt("code", code);
@@ -46,6 +52,7 @@ public class PositionError {
     error.putInt("PERMISSION_DENIED", PERMISSION_DENIED);
     error.putInt("POSITION_UNAVAILABLE", POSITION_UNAVAILABLE);
     error.putInt("TIMEOUT", TIMEOUT);
+    error.putInt("ACTIVITY_NULL", ACTIVITY_NULL);
     return error;
   }
 }


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
This PR addresses issue https://github.com/michalchudziak/react-native-geolocation/issues/217 in which app is crashing probably because activity returned by `mReactContext.getCurrentActivity()` is null.

As suggested in my comment https://github.com/michalchudziak/react-native-geolocation/issues/217#issuecomment-1315307848 I added a null check in PlayServicesLocationManager.getCurrentLocationData.

If currentActivity is returned as null, we invoke the `error` callback with a new PositionError (`ACTIVITY_NULL`), and then just `return` to end the method execution.

## Questions

1. I added the new `ACTIVITY_NULL` error to the PositionError class. But this is not a position error, more some underlying Android/React Native error (I don't know 😅). Adding this to PositionError is quick and easy, but to be precise and clean it would make sense to put it in another class, eg. `UnexpectedError` or something like that..
Also this breaks the so called "feature parity with iOS", and makes the `GeolocationError` TypeScript type inaccurate.
Any thoughts on that?

2. At first I tried to call the error callback with `emitError`, but the error was not reaching the JS. So I changed to `error.invoke`, and then the error was reaching the JS. I see that you made changes to how the error callback is called in the last two commit (741a353f00885e62a1694a7f6f78fe7c83eb102f, 362bf80ec5b186294a0739f6cb39353b3b6c4cd3), and I am wondering if these changes are maybe a mistake?

3. Unrelated: I tried to run the e2e tests, but noticed the script does not exist in package.json. Maybe [CONTRIBUTING.md](https://github.com/michalchudziak/react-native-geolocation/blob/master/CONTRIBUTING.md) should be updated?

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
I added the changes in my app with a patch and then hardcoded
```diff
- Activity currentActivity = mReactContext.getCurrentActivity();
+ Activity currentActivity = null;
```
to make sure that the null check was working and that the error was reaching the JS, which it did.

Then, I changed it back to what it's supposed to be
```diff
+ Activity currentActivity = mReactContext.getCurrentActivity();
- Activity currentActivity = null;
```
and made sure the location data was reaching the JS, which it did.
