### PR TITLE
Update BaseLocationManager.java

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/geolocation/BaseLocationManager.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/BaseLocationManager.java
@@ -49,8 +49,10 @@ public abstract class BaseLocationManager {
     }
 
     protected static void putIntoMap(WritableMap map, String key, Object value) {
-        if (value instanceof Integer || value instanceof Long) {
+        if (value instanceof Integer) {
             map.putInt(key, (Integer) value);
+        } else if (value instanceof Long) {
+            map.putInt(key, ((Long) value).intValue());
         } else if (value instanceof Float) {
             map.putDouble(key, (Float) value);
         } else if (value instanceof Double) {


### PR DESCRIPTION
Fixes the following exception when trying to cast a Long to an Integer.

Fatal Exception: java.lang.ClassCastException: java.lang.Long cannot be cast to java.lang.Integer
at com.reactnativecommunity.geolocation.BaseLocationManager.putIntoMap(BaseLocationManager.java:87)