### PR TITLE
Set default timeout to 10 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Invokes the success callback once with the latest location info.
 
 Supported options:
 
-* `timeout` (ms) - Is a positive value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position. Defaults to INFINITY.
+* `timeout` (ms) - Is a positive value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position. Defaults to 10 minutes.
 * `maximumAge` (ms) - Is a positive value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return. If set to 0, it means that the device cannot use a cached position and must attempt to retrieve the real current position. If set to Infinity the device will always return a cached position regardless of its age. Defaults to INFINITY.
 * `enableHighAccuracy` (bool) - Is a boolean representing if to use GPS or not. If set to true, a GPS position will be requested. If set to false, a WIFI location will be requested.
 
@@ -257,7 +257,7 @@ Supported options:
 
 * `interval` (ms) -- (Android only) The rate in milliseconds at which your app prefers to receive location updates. Note that the location updates may be somewhat faster or slower than this rate to optimize for battery usage, or there may be no updates at all (if the device has no connectivity, for example).
 * `fastestInterval` (ms) -- (Android only) The fastest rate in milliseconds at which your app can handle location updates. Unless your app benefits from receiving updates more quickly than the rate specified in `interval`, you don't need to set it.
-* `timeout` (ms) - Is a positive value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position. Defaults to INFINITY.
+* `timeout` (ms) - Is a positive value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position. Defaults to 10 minutes.
 * `maximumAge` (ms) - Is a positive value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return. If set to 0, it means that the device cannot use a cached position and must attempt to retrieve the real current position. If set to Infinity the device will always return a cached position regardless of its age. Defaults to INFINITY.
 * `enableHighAccuracy` (bool) - Is a boolean representing if to use GPS or not. If set to true, a GPS position will be requested. If set to false, a WIFI location will be requested.
 * `distanceFilter` (m) - The minimum distance from the previous location to exceed before returning a new location. Set to 0 to not filter locations. Defaults to 100m.

--- a/android/src/main/java/com/reactnativecommunity/geolocation/BaseLocationManager.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/BaseLocationManager.java
@@ -109,7 +109,7 @@ public abstract class BaseLocationManager {
             int fastestInterval =
                     map.hasKey("fastestInterval") ? map.getInt("fastestInterval") : -1;
             long timeout =
-                    map.hasKey("timeout") ? (long) map.getDouble("timeout") : Long.MAX_VALUE;
+                    map.hasKey("timeout") ? (long) map.getDouble("timeout") : 1000 * 60 * 10;
             double maximumAge =
                     map.hasKey("maximumAge") ? map.getDouble("maximumAge") : Double.POSITIVE_INFINITY;
             boolean highAccuracy =

--- a/ios/RNCGeolocation.mm
+++ b/ios/RNCGeolocation.mm
@@ -75,7 +75,7 @@ RCT_ENUM_CONVERTER(RNCGeolocationAuthorizationLevel, (@{
   : [RCTConvert double:options[@"distanceFilter"]] ?: kCLDistanceFilterNone;
 
   return (RNCGeolocationOptions){
-    .timeout = [RCTConvert NSTimeInterval:options[@"timeout"]] ?: INFINITY,
+    .timeout = [RCTConvert NSTimeInterval:options[@"timeout"]] ?: 1000 * 60 * 2,
     .maximumAge = [RCTConvert NSTimeInterval:options[@"maximumAge"]] ?: INFINITY,
     .accuracy = [RCTConvert BOOL:options[@"enableHighAccuracy"]] ? kCLLocationAccuracyBest : RNC_DEFAULT_LOCATION_ACCURACY,
     .distanceFilter = distanceFilter,

--- a/ios/RNCGeolocation.mm
+++ b/ios/RNCGeolocation.mm
@@ -75,7 +75,7 @@ RCT_ENUM_CONVERTER(RNCGeolocationAuthorizationLevel, (@{
   : [RCTConvert double:options[@"distanceFilter"]] ?: kCLDistanceFilterNone;
 
   return (RNCGeolocationOptions){
-    .timeout = [RCTConvert NSTimeInterval:options[@"timeout"]] ?: 1000 * 60 * 2,
+    .timeout = [RCTConvert NSTimeInterval:options[@"timeout"]] ?: 1000 * 60 * 10,
     .maximumAge = [RCTConvert NSTimeInterval:options[@"maximumAge"]] ?: INFINITY,
     .accuracy = [RCTConvert BOOL:options[@"enableHighAccuracy"]] ? kCLLocationAccuracyBest : RNC_DEFAULT_LOCATION_ACCURACY,
     .distanceFilter = distanceFilter,


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
On Android, if we call `getCurrentPosition` using the `"android"` provider, we default to `Long.MAX_VALUE` if no `timeout` is passed.

In turn, this `timeout` gets passed to  [`mHandler.postDelayed`](https://github.com/michalchudziak/react-native-geolocation/blob/master/android/src/main/java/com/reactnativecommunity/geolocation/AndroidLocationManager.java#L207), which is meant to reject the call once the timeout has been reached. 

However, `postDelayed` makes use of `sendMessageDelayed` under the hood, which then finally calls [`sendMessageAtTime`](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/os/Handler.java#693) - using the `delay` and adding `SystemClock.uptimeMillis()` to it. 

Essentially, using `Long.MAX_VALUE` causes an overflow here, and leads to the reject timeout triggering immediately.

It could be argued that having an `infinite` timeout as default does not make sense anyway, and setting it to 10 minutes is much more sensible.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Call `getCurrentPosition` with no `timeout` specified - it should return a location instead of rejecting with `Location request timed out`.