### PR TITLE
Fix a bug with negative distance filter passed to options

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/geolocation/PlayServicesLocationManager.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/PlayServicesLocationManager.java
@@ -128,7 +128,9 @@ public class PlayServicesLocationManager extends BaseLocationManager {
             locationRequest.setFastestInterval(locationOptions.fastestInterval);
         }
         locationRequest.setExpirationDuration((long) locationOptions.maximumAge);
-        locationRequest.setSmallestDisplacement(locationOptions.distanceFilter);
+        if (locationOptions.distanceFilter >= 0) {
+            locationRequest.setSmallestDisplacement(locationOptions.distanceFilter);
+        }
         locationRequest.setPriority(
                 locationOptions.highAccuracy ? LocationRequest.PRIORITY_HIGH_ACCURACY : LocationRequest.PRIORITY_LOW_POWER
         );


### PR DESCRIPTION
# Overview
A fix for: https://github.com/transistorsoft/react-native-background-geolocation/issues/893 for some reason on Android 8, there ale calls to this function with a negative value preceding the correct call. This condition ensures that no negative value is ever passed to the `setSmallestDisplacement` method, as it crashes in such cases.
