### PR TITLE
fix: NPE when removing single location updates

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/geolocation/PlayServicesLocationManager.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/PlayServicesLocationManager.java
@@ -71,7 +71,7 @@ public class PlayServicesLocationManager extends BaseLocationManager {
                                     Location location = locationResult.getLastLocation();
                                     success.invoke(locationToMap(location));
 
-                                    mFusedLocationClient.removeLocationUpdates(mSingleLocationCallback);
+                                    mFusedLocationClient.removeLocationUpdates(this);
                                     mSingleLocationCallback = null;
                                 }
 


### PR DESCRIPTION
# Overview
When getting the location from playServices, the app crashes for some users. I'm not able to reproduce it. 
It has also been reported [Here](https://github.com/michalchudziak/react-native-geolocation/issues/241)


# Test Plan
I'm assuming the fix is straightforward. We deployed a patch of this in our app with success.
