### PR TITLE
use latest play services version 21.0.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -133,7 +133,7 @@ repositories {
 dependencies {
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
-  implementation 'com.google.android.gms:play-services-location:20.0.0'
+  implementation 'com.google.android.gms:play-services-location:21.0.1'
 }
 
 if (isNewArchitectureEnabled()) {


### PR DESCRIPTION
# Overview
Google [released](https://developers.google.com/android/guides/releases#november_03_2022) `play-services-location` `21.0.1` back in 11/2022 so seems like a good time to update, also due to other dependencies requiring `21.0.1` my project resolves to this version, when I attempt to use `react-native-geolocation` with `21.0.1` in my app I get the following error:
![Screenshot_1681836121](https://user-images.githubusercontent.com/197929/232899400-5ed815ef-d71f-4587-8f2f-3dceebbc7ab8.png)

This is actually [fixed](https://developers.google.com/android/guides/releases#october_13_2022) by updating to `21.0.0` however seems better to update to latest.

# Test Plan
Ran all tests in the `package.json` scripts section, ran sample app and tested it worked, and tested in my own app where I initially noticed the issue, tested changes by updating `@react-native-community/geolocation` in `dependencies` to use local path of git repo for my fork.
