### PR TITLE
chore: Update README.md for android setup running on React Native 0.65 and bellow 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Android API >= 18 Positions will also contain a `mocked` boolean to indicate if 
   Failure to do so may result in a hard crash.
 </p>
 
-#### For React Native < 0.65 on Android we need to link manually, follow the steps bellow: 
+<details>
+  <summary><b>For React Native < 0.65 on Android we need to link manually</b></summary>
+
 
 - android/settings.gradle
 ```
@@ -102,6 +104,7 @@ protected List<ReactPackage> getPackages() {
       return packages;
 }
 ```
+</details>
 
 ## Migrating from the core `react-native` module
 This module was created when the Geolocation was split out from the core of React Native. As a browser polyfill, this API was available through the `navigator.geolocation` global - you didn't need to import it. To migrate to this module you need to follow the installation instructions above and change following code:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,37 @@ Android API >= 18 Positions will also contain a `mocked` boolean to indicate if 
   Failure to do so may result in a hard crash.
 </p>
 
+#### For React Native < 0.65 on Android we need to link manually, follow the steps bellow: 
+
+- android/settings.gradle
+```
+include ':react-native-community-geolocation'
+project(':react-native-community-geolocation').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/geolocation/android')
+```
+- android/app/build.gradle
+```
+dependencies {
+   ...
+   implementation project(':react-native-community-geolocation')
+}
+```
+- android/app/src/main/.../MainApplication.java
+  On imports section:
+```java
+import com.reactnativecommunity.geolocation.GeolocationPackage;
+```
+  In the class at `getPackages` method: 
+```java
+@Override
+protected List<ReactPackage> getPackages() {
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      packages.add(new GeolocationPackage()); // <== add this line
+      return packages;
+}
+```
+
 ## Migrating from the core `react-native` module
 This module was created when the Geolocation was split out from the core of React Native. As a browser polyfill, this API was available through the `navigator.geolocation` global - you didn't need to import it. To migrate to this module you need to follow the installation instructions above and change following code:
 


### PR DESCRIPTION
# Overview

- Recently used the library on an old React Native Project, worked just fine for iOS but it failed to integrate with Android. After some search I found this issue #221 .

- The steps on [this comment](https://github.com/michalchudziak/react-native-geolocation/issues/221#issuecomment-1365035110) was the solution for my project that is running on React Native 0.64

- This PR adds a section with the necessary steps for projects running bellow React Native 0.65

# Screenshot
<img width="1106" alt="Captura de Tela 2023-07-17 às 17 45 03" src="https://github.com/michalchudziak/react-native-geolocation/assets/22153156/272eb3a2-31e4-43bd-ad57-0642dae5c0d7">

