### PR TITLE
Default `auto` to Play Services location provider if available

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/geolocation/GeolocationModule.java
+++ b/android/src/main/java/com/reactnativecommunity/geolocation/GeolocationModule.java
@@ -51,7 +51,7 @@ public class GeolocationModule extends ReactContextBaseJavaModule {
     ReactApplicationContext reactContext = mLocationManager.mReactContext;
     if (Objects.equals(config.locationProvider, "android") && mLocationManager instanceof PlayServicesLocationManager) {
       mLocationManager = new AndroidLocationManager(reactContext);
-    } else if (Objects.equals(config.locationProvider, "playServices") && mLocationManager instanceof AndroidLocationManager) {
+    } else if ((Objects.equals(config.locationProvider, "playServices") || Objects.equals(config.locationProvider, "auto")) && mLocationManager instanceof AndroidLocationManager) {
       GoogleApiAvailability availability = new GoogleApiAvailability();
       if (availability.isGooglePlayServicesAvailable(reactContext.getApplicationContext()) == ConnectionResult.SUCCESS) {
         mLocationManager = new PlayServicesLocationManager(reactContext);


### PR DESCRIPTION
This PR reflects the one-line change proposed in [#266](https://github.com/michalchudziak/react-native-geolocation/issues/266)