### PR TITLE
Remove RCT-Folly version hardcoding

### DIFF
--- a/react-native-geolocation.podspec
+++ b/react-native-geolocation.podspec
@@ -1,7 +1,6 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-folly_version = '2021.07.22.00'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -28,7 +27,7 @@ Pod::Spec.new do |s|
     }
 
     s.dependency "React-Codegen"
-    s.dependency "RCT-Folly", folly_version
+    s.dependency "RCT-Folly"
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"


### PR DESCRIPTION
Hey. Installing pods currently fails when using react-native 0.73.0 and new architecture.
This is due to version conflict with Folly. react-native-geolocation hardcodes usage of `2021.07.22.00`.
Presumably there is no reason for this, so this PR removes that. 

```
[!] CocoaPods could not find compatible versions for pod "RCT-Folly":
  In Podfile:
    RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)

    React-RCTAppDelegate (from `../node_modules/react-native/Libraries/AppDelegate`) was resolved to 0.73.0, which depends on
      RCT-Folly

    ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`) was resolved to 0.73.0, which depends on
      RCT-Folly (= 2022.05.16.00)

    react-native-geolocation (from `../node_modules/@react-native-community/geolocation`) was resolved to 3.0.6, which depends on
      RCT-Folly (= 2021.07.22.00)
```

Cheers.