### PR TITLE
build: update legacy codegen config

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,12 +133,11 @@
     ]
   },
   "codegenConfig": {
-    "libraries": [
-      {
-        "name": "RNCGeolocationSpec",
-        "type": "modules",
-        "jsSrcsDir": "js"
-      }
-    ]
+    "name": "RNCGeolocationSpec",
+    "type": "modules",
+    "jsSrcsDir": "js",
+    "android": {
+      "javaPackageName": "com.reactnativecommunity.geolocation"
+    }
   }
 }


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Current implementation of `codegen` config contains legacy `libraries` syntax, I have update it to new version removing the `codegen` warning: 


```
[Codegen] Found @react-native-community/geolocation
[Codegen] CodegenConfig Deprecated Setup for @react-native-community/geolocation.
    The configuration file still contains the codegen in the libraries array.
    If possible, replace it with a single object.

BEFORE:
    {
      // ...
      "codegenConfig": {
        "libraries": [
          {
            "name": "libName1",
            "type": "all|components|modules",
            "jsSrcsRoot": "libName1/js"
          },
          {
            "name": "libName2",
            "type": "all|components|modules",
            "jsSrcsRoot": "libName2/src"
          }
        ]
      }
    }
    AFTER:
    {
      "codegenConfig": {
        "name": "libraries",
        "type": "all",
        "jsSrcsRoot": "."
      }
    }
 ```




# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Run example app using newArch and validate if builds are passing. 

Outcome:
Both iOS and Android builds are passing while using newArch.
