### PR TITLE
build: added namespace for AGP version 7+. This should fix compatibil…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,11 @@ if (isNewArchitectureEnabled()) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace = "com.reactnativecommunity.geolocation"
+  }
+
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
   defaultConfig {


### PR DESCRIPTION
…ity issues with gradle 8.

Fixes issue [#324](https://github.com/michalchudziak/react-native-geolocation/issues/324)

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Some Android dependencies require Gradle 8. The only way this (rn geo location) can be used with Gradle 8 is by adding the namespace value. 


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Configure react native project with android gradle 8. Sync / build project. 