### PR TITLE
feat: add visionos support

### DIFF
--- a/ios/RNCGeolocation.mm
+++ b/ios/RNCGeolocation.mm
@@ -190,7 +190,9 @@ RCT_EXPORT_MODULE()
 
   if (@available(iOS 14.0, *)) {
     if (
+#if ! TARGET_OS_VISION
       _lastUpdatedAuthorizationStatus == kCLAuthorizationStatusAuthorizedAlways ||
+#endif
       _lastUpdatedAuthorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse
     ) {
       [self startMonitoring];
@@ -202,16 +204,24 @@ RCT_EXPORT_MODULE()
 
 - (void)startMonitoring
 {
-  _usingSignificantChanges
-    ? [_locationManager startMonitoringSignificantLocationChanges]
-    : [_locationManager startUpdatingLocation];
+#if !TARGET_OS_VISION
+   _usingSignificantChanges
+     ? [_locationManager startMonitoringSignificantLocationChanges]
+     : [_locationManager startUpdatingLocation];
+#else
+    [_locationManager startUpdatingLocation];
+#endif
 }
 
 - (void)stopMonitoring
 {
-  _usingSignificantChanges
-    ? [_locationManager stopMonitoringSignificantLocationChanges]
-    : [_locationManager stopUpdatingLocation];
+#if !TARGET_OS_VISION
+   _usingSignificantChanges
+     ? [_locationManager stopMonitoringSignificantLocationChanges]
+     : [_locationManager stopUpdatingLocation];
+#else
+    [_locationManager stopUpdatingLocation];
+#endif
 }
 
 #pragma mark - Timeout handler
@@ -273,8 +283,10 @@ RCT_REMAP_METHOD(requestAuthorization, requestAuthorization:(RCTResponseSenderBl
 
   // Request location access permission
   if (wantsAlways) {
+#if !TARGET_OS_VISION
     [_locationManager requestAlwaysAuthorization];
     [self enableBackgroundLocationUpdates];
+#endif
   } else if (wantsWhenInUse) {
     [_locationManager requestWhenInUseAuthorization];
   }
@@ -282,6 +294,7 @@ RCT_REMAP_METHOD(requestAuthorization, requestAuthorization:(RCTResponseSenderBl
 
 - (void)enableBackgroundLocationUpdates
 {
+#if !TARGET_OS_VISION
   // iOS 9+ requires explicitly enabling background updates
   NSArray *backgroundModes  = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
   if (backgroundModes && [backgroundModes containsObject:@"location"]) {
@@ -289,6 +302,7 @@ RCT_REMAP_METHOD(requestAuthorization, requestAuthorization:(RCTResponseSenderBl
       [_locationManager setAllowsBackgroundLocationUpdates:YES];
     }
   }
+#endif
 }
 
 
@@ -445,7 +459,9 @@ RCT_REMAP_METHOD(getCurrentPosition, getCurrentPosition:(RNCGeolocationOptions)o
   }
     
   if (
+#if !TARGET_OS_VISION
     currentStatus == kCLAuthorizationStatusAuthorizedAlways ||
+#endif
     currentStatus == kCLAuthorizationStatusAuthorizedWhenInUse
   ) {
     if (_queuedAuthorizationCallbacks != nil && _queuedAuthorizationCallbacks.count > 0){

--- a/react-native-geolocation.podspec
+++ b/react-native-geolocation.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "9.0"
+  s.platforms     = { :ios => '9.0', :visionos => '1.0' }
 
   s.source       = { :git => "https://github.com/react-native-community/react-native-geolocation.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,mm}"


### PR DESCRIPTION
# Overview

Hey! 

This PR adds visionOS support for the library. One thing is that visionOS doesn't support the "always" geolocation mode so I had to add some ifdefs to make it work.

I've tested the library in another project using patch-package and everything worked smoothly.

# Test Plan
Test the app on visionOS