### PR TITLE
chore: fix clear watch logic

### DIFF
--- a/ios/RNCGeolocation.mm
+++ b/ios/RNCGeolocation.mm
@@ -309,6 +309,10 @@ RCT_REMAP_METHOD(requestAuthorization, requestAuthorization:(RCTResponseSenderBl
 RCT_REMAP_METHOD(startObserving, startObserving:(RNCGeolocationOptions)options)
 {
   checkLocationConfig();
+    
+  if (_observingLocation) {
+    [self stopObserving];
+  }
 
   // Select best options
   _observerOptions = options;
@@ -376,6 +380,12 @@ RCT_REMAP_METHOD(getCurrentPosition, getCurrentPosition:(RNCGeolocationOptions)o
     successBlock(@[_lastLocationEvent]);
     return;
   }
+    
+  BOOL didPause = NO;
+  if (_observingLocation) {
+    [self stopObserving];
+    didPause = YES;
+  }
 
   // Create request
   RNCGeolocationRequest *request = [RNCGeolocationRequest new];
@@ -400,6 +410,10 @@ RCT_REMAP_METHOD(getCurrentPosition, getCurrentPosition:(RNCGeolocationOptions)o
   [self beginLocationUpdatesWithDesiredAccuracy:accuracy
                                  distanceFilter:options.distanceFilter
                           useSignificantChanges:options.useSignificantChanges];
+
+  if (didPause) {
+    [self startObserving];
+  }
 }
 
 #pragma mark - CLLocationManagerDelegate


### PR DESCRIPTION
# Overview
Solves https://github.com/michalchudziak/react-native-geolocation/issues/328 https://github.com/michalchudziak/react-native-geolocation/issues/323
Fixed issues with cleaning observers on multiple `watchPosition` / `getCurrentPosition` calls.


# Test Plan
- `getCurrentPosition` calls should work after `watchPosition` was called
- `watchPosition` event should be emitted after `getCurrentPosition` was called