### PR TITLE
fix: add missing mock field to GeolocationResponse

### DIFF
--- a/js/NativeRNCGeolocation.ts
+++ b/js/NativeRNCGeolocation.ts
@@ -29,6 +29,10 @@ export type GeolocationResponse = {
     speed: number | null;
   };
   timestamp: number;
+  /**
+   * Only set on Android API >= 18 or iOS >= 15
+   */
+  mocked?: boolean;
 };
 
 export type GeolocationError = {


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Type the `mocked` field correctly.
Closes #287 

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Tried if the field shows up in autocomplete in an internal project. It does show up :)