### PR TITLE
Fix `startObserving` function call bug

### DIFF
--- a/ios/RNCGeolocation.mm
+++ b/ios/RNCGeolocation.mm
@@ -412,7 +412,7 @@ RCT_REMAP_METHOD(getCurrentPosition, getCurrentPosition:(RNCGeolocationOptions)o
                           useSignificantChanges:options.useSignificantChanges];
 
   if (didPause) {
-    [self startObserving];
+    [self startObserving:_observerOptions];
   }
 }
 


### PR DESCRIPTION
The call

```objc
[self startObserving];
```

is an empty inherited function, so the existing implementation does not restart the observer.

To call the local `startObserving` method in `RNCGeolocation.mm`, it needs an argument:

```objc
_[self_ startObserving:_observerOptions];
```